### PR TITLE
Fixing typo in RawData example

### DIFF
--- a/examples/RawData/RawData.ino
+++ b/examples/RawData/RawData.ino
@@ -27,7 +27,7 @@ void loop() {
 
     ratio_NH3 = Rs_NH3 / R0_NH3;
     ratio_CO  = Rs_CO / R0_CO;
-    ratio_NO2 = Rs_NH3 / R0_NO2;
+    ratio_NO2 = Rs_NO2 / R0_NO2;
 
     Serial.println("R0:");
     Serial.print(R0_NH3);


### PR DESCRIPTION
There was a typo in the RawData.ino example, the ratio for the NO2 sensor was computed using the NH3 sensor value.
Fixed.